### PR TITLE
Adding Changelog directory with Changelog fragment dir

### DIFF
--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -1,0 +1,22 @@
+---
+release_tag_re: '(v(?:[\d.ab\-]|rc)+)'
+pre_release_tag_re: '(?P<pre_release>(?:[ab]|rc)+\d*)$'
+notesdir: fragments
+prelude_section_name: release_summary
+sections:
+- ['major_changes', 'Major Changes']
+- ['minor_changes', 'Minor Changes']
+- ['deprecated_features', 'Deprecated Features']
+- ['removed_features', 'Removed Features (previously deprecated)']
+- ['new_lookup_plugins', 'New Lookup Plugins']
+- ['new_callback_plugins', 'New Callback Plugins']
+- ['new_connection_plugins', 'New Connection Plugins']
+- ['new_test_plugins', 'New Test Plugins']
+- ['new_filter_plugins', 'New Filter Plugins']
+- ['new_modules', 'New Modules']
+- ['new_tasks', 'New Tasks']
+- ['new_functions', 'New Functions']
+- ['new_parser_templates', 'New Parser Templates']
+- ['bugfixes', 'Bugfixes']
+- ['known_issues', 'Known Issues']
+- ['docs', 'Documentation Updates']

--- a/changelogs/fragments/v0-initial-release.yaml
+++ b/changelogs/fragments/v0-initial-release.yaml
@@ -1,0 +1,9 @@
+major_changes:
+- Initial release of the ``cisco_iosxr`` Ansible role.
+- This role provides functions to perform automation activities on Cisco IOSXR devices.
+
+new_functions:
+- NEW ``get_facts`` function can be used to collect facts from Cisco IOSXR devices.
+- NEW ``config_manager/get`` function returns the either the current active or current saved configuration from Cisco IOSXR devices.
+- NEW ``config_manager/load`` function provides a means to load a configuration file onto a target device running Cisco IOSXR.
+- NEW ``config_manager/save`` function saves the current active (running) configuration to the startup configuration.


### PR DESCRIPTION
Added changelog directory with `config.yaml` and fragment directory with `v0-initial-release.yaml` with changelogs for **first** cisco_iosxr role release.