### PR TITLE
Switch linters to python3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
 
 [testenv:linters]
+basepython = python3
 commands =
   flake8 {posargs}
 


### PR DESCRIPTION
Since we run on fedora, lets use python3 for this.  It is also how other
roles work today.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>