### PR TITLE
Configure Cisco IOS-XR device System properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Please see the documentation link for each function for details on how to use
 the function in an Ansible playbook.
 
 * get_facts [[source]](https://github.com/ansible-network/cisco_iosxr/blob/devel/tasks/get_facts.yaml) [[docs]](https://github.com/ansible-network/cisco_iosxr/blob/devel/docs/get_facts.md)
+* configure_vlans [[source]](https://github.com/ansible-network/cisco_iosxr/blob/devel/tasks/configure_vlans.yaml) [[docs]](https://github.com/ansible-network/cisco_iosxr/blob/devel/docs/configure_vlans.md)
+* configure_system_properties [[source]](https://github.com/ansible-network/cisco_iosxr/blob/devel/tasks/configure_system_properties) [[docs]](https://github.com/ansible-network/cisco_iosxr/blob/devel/docs/configure_system_properties.md)
 
 ## License
 

--- a/docs/configure_system_properties.md
+++ b/docs/configure_system_properties.md
@@ -102,7 +102,8 @@ value the role will continue to run without any failure.
 
 ### vrf_name
 
-VRF name that need to be configured for the Cisco IOS-XR device.
+VRF name that need to be configured for the Cisco IOS-XR device. Also, this is mandatory
+parameter for VRF configuration.
 
 The default value is `omit` which means even if the user doesn't pass the respective
 value the role will continue to run without any failure.

--- a/docs/configure_system_properties.md
+++ b/docs/configure_system_properties.md
@@ -1,0 +1,171 @@
+# Configure System properties on the device
+
+The `configure_system_properties` function can be used to set system properties on 
+Cisco IOS-XR devices.  This function is only supported over `network_cli` connection
+type and requires the `ansible_network_os` value set to `iosxr`.
+
+## How to set System properties on the device
+
+To set System properties on the device, simply include this function in the playbook
+using either the `roles` directive or the `tasks` directive.  If no other
+options are provided, then all of the available facts will be collected for the
+device.
+
+Below is an example of how to use the `roles` directive to set system properties
+on the Cisco IOS-XR device.
+
+```
+- hosts: iosxr
+
+  roles:
+  - name ansible-network.cisco_iosxr
+    function: configure_system_properties
+  vars:
+    system_properties:
+      - hostname: test-iosxr
+        domain_name: hostname.com
+        name_server: 192.168.1.1
+        vrf_name: vrf-01
+        vrf_description: new vrf named as vrf-01
+        vrf_address_family: ipv4 multicast
+        vrf_apply_group: vrf-group
+        vrf_fallback: vrf-fallback-name
+        vrf_mode: big
+        vrf_vpn: id 4:ff
+        vrf_remote_route_filter: disable
+```
+
+The above playbook will set the hostname, domain-name and the name-server values to
+the host under the `iosxr` top level key.  
+
+### Implement using tasks
+
+The `configure_system_properties` function can also be implemented using the `tasks` 
+directive instead of the `roles` directive.  By using the `tasks` directive, you can
+control when the fact collection is run. 
+
+Below is an example of how to use the `configure_system_properties` function with `tasks`.
+
+```
+- hosts: iosxr
+
+  tasks:
+    - name: set system properties to iosxr devices
+      import_role:
+        name: ansible-network.cisco_iosxr
+        tasks_from: configure_system_properties
+      vars:
+        system_properties:
+          - hostname: test-iosxr
+            domain_name: hostname.com
+            name_server: 192.168.1.1
+            vrf_name: vrf-01
+            vrf_description: new vrf named as vrf-01
+            vrf_address_family: ipv4 multicast
+            vrf_apply_group: vrf-group
+            vrf_fallback: vrf-fallback-name
+            vrf_mode: big
+            vrf_vpn: id 4:ff
+            vrf_remote_route_filter: disable
+```
+
+## Adding new parsers
+
+Over time new parsers can be added (or updated) to the role to add additional
+or enhanced functionality.  To add or update parsers perform the following
+steps:
+
+* Add (or update) command parser located in `parse_templates/cli`
+
+## Arguments
+
+### hostname
+
+This will set the System host name for the Cisco IOS-XR device.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### domain_name
+
+This will set the System domain name for the Cisco IOS-XR device.
+
+The default value is `omit` which means even if the user doesn't pass the respective 
+value the role will continue to run without any failure.
+
+### name_server
+
+This will set the Domain Name Server (DNS) for the Cisco IOS-XR device.
+
+The default value is `omit` which means even if the user doesn't pass the respective 
+value the role will continue to run without any failure.
+
+### vrf_name
+
+VRF name that need to be configured for the Cisco IOS-XR device.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### vrf_description
+
+A description for the VRF to be configured for the Cisco IOS-XR device.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### vrf_address_family
+
+AFI/SAFI configuration for the VRF to be configured for the Cisco IOS-XR device.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### vrf_apply_group
+
+Apply configuration from a group to be configured for the Cisco IOS-XR device.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### vrf_fallback
+
+Fallback vrf for the VRF to be configured for the Cisco IOS-XR device.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### vrf_mode
+
+VRF mode which determines the max prefix scale.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+            
+### vrf_vpn
+
+VPN ID for the VRF to be configured for the Cisco IOS-XR device.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### vrf_remote_route_filter:
+
+Enable/Disable remote route filtering per VRF.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### state
+
+This will set the hostname, domain-name, name-server and VRF value to the Cisco IOS-XR 
+device and if the value of the state is changed to `absent`, role will go ahead and try 
+to delete the hostname, domain-name, name-server and VRF passed via the arguments.
+
+The default value is `present` which means even if the user doesn't pass the respective
+argument, the role will go ahead and try to set the hostname, domain-name, name-server 
+and VRF via the arguments passed to the Cisco IOS-XR device.
+
+## Notes
+
+None

--- a/tasks/configure_system_properties.yaml
+++ b/tasks/configure_system_properties.yaml
@@ -1,0 +1,8 @@
+---
+- name: "fetch template for configuring system property(s)"
+  set_fact:
+    iosxr_config_text: "{{ lookup('config_template', 'configure_system_properties.j2') }}"
+  when: sys_props
+
+- include_tasks: config_manager/load.yaml
+  when: sys_props

--- a/templates/configure_system_properties.j2
+++ b/templates/configure_system_properties.j2
@@ -1,0 +1,50 @@
+{% for sys_prop in sys_props %}
+
+{% if sys_prop.state is defined and sys_prop.state == 'absent' %}
+
+{% if sys_prop.hostname is defined %}
+no hostname {{ sys_prop.hostname }}
+{% endif %}
+
+{% if sys_prop.domain_name is defined %}
+no domain name {{ sys_prop.domain_name }}
+{% endif %}
+
+{% if sys_prop.domain_name_server is defined %}
+no domain name-server {{ sys_prop.domain_name_server }}
+{% endif %}
+
+{% if sys_prop.vrf_name is defined %}
+no vrf {{ sys_prop.vrf_name }}
+{% endif %}
+
+
+{% else %}
+
+
+{% if sys_prop.hostname is defined %}
+hostname {{ sys_prop.hostname }}
+{% endif %}
+
+{% if sys_prop.domain_name is defined %}
+domain name {{ sys_prop.domain_name }}
+{% endif %}
+
+{% if sys_prop.domain_name_server is defined %}
+domain name-server {{ sys_prop.domain_name_server | default(omit) }}
+{% endif %}
+
+{% if sys_prop.vrf_name is defined %}
+vrf {{ sys_prop.vrf_name }}
+address-family {{ sys_prop.vrf_address_family | default(omit) }}
+apply-group {{ sys_prop.vrf_apply_group | default(omit) }}
+description {{ sys_prop.description | default(omit) }}
+fallback-vrf {{ sys_prop.vrf_fallback | default(omit) }}
+mode {{ sys_prop.vrf_mode | default(omit) }}
+vpn {{ sys_prop.vrf_vpn | default(omit) }}
+remote-route-filtering {{ sys_prop.vrf_remote_route_filter | default(omit) }}
+{% endif %}
+
+
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
Added `configure_sys_props` and `configure_system_properties` jinja template for Cisco IOS-XR device provider to configure system properties using `iosxr` device provider role.

To configure system properties via this role user needs to build their playbook as:
```
---
- hosts: iosxr
  gather_facts: no
  tasks:
    - import_role:
        name: cisco_iosxr
        tasks_from: configure_system_properties
      vars:
        system_properties:
          - hostname: test-iosxr
            domain_name: hostname.com
            name_server: 192.168.1.1
            vrf_name: vrf-01
            vrf_description: new vrf named as vrf-01
            vrf_address_family: ipv4 multicast
            vrf_apply_group: vrf-group
            vrf_fallback: vrf-fallback-name
            vrf_mode: big
            vrf_vpn: id 4:ff
            vrf_remote_route_filter: disable
            #state: absent
```