### PR TITLE
Adding Configure lldp role support for Cisco-IOSXR devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ the function in an Ansible playbook.
 * get_facts [[source]](https://github.com/ansible-network/cisco_iosxr/blob/devel/tasks/get_facts.yaml) [[docs]](https://github.com/ansible-network/cisco_iosxr/blob/devel/docs/get_facts.md)
 * configure_vlans [[source]](https://github.com/ansible-network/cisco_iosxr/blob/devel/tasks/configure_vlans.yaml) [[docs]](https://github.com/ansible-network/cisco_iosxr/blob/devel/docs/configure_vlans.md)
 * configure_system_properties [[source]](https://github.com/ansible-network/cisco_iosxr/blob/devel/tasks/configure_system_properties.yaml) [[docs]](https://github.com/ansible-network/cisco_iosxr/blob/devel/docs/configure_system_properties.md)
+* configure_lldp [[source]](https://github.com/ansible-network/cisco_iosxr/blob/devel/tasks/configure_lldp.yaml) [[docs]](https://github.com/ansible-network/cisco_iosxr/blob/devel/docs/configure_lldp.md)
 
 ### Config Manager
 

--- a/docs/configure_lldp.md
+++ b/docs/configure_lldp.md
@@ -1,0 +1,145 @@
+# Configure LLDP on the device
+
+The `configure_lldp` function can be used to set LLDP on Cisco IOS-XR devices.
+This function is only supported over `network_cli` connection type and 
+requires the `ansible_network_os` value set to `iosxr`.
+
+## How to set LLDP on the device
+
+To set LLDP on the device, simply include this function in the playbook
+using either the `roles` directive or the `tasks` directive.  If no other
+options are provided, then all of the available facts will be collected for 
+the device.
+
+Below is an example of how to use the `roles` directive to set VLANs on the 
+Cisco IOS-XR device.
+
+```
+- hosts: iosxr
+
+  roles:
+  - name ansible-network.cisco_iosxr
+    function: configure_lldp
+  vars:
+    lldp:
+      - holdtime: 60
+        reinit: 4
+        timer: 60
+        tlv-select: management-address
+        interface: GigabitEthernet 0/0/0/3
+        receive: disable
+        transmit: disable
+```
+
+The above playbook will set the LLDP with holdtime, reinit, tlv-select, receive,
+and transmit to particular interface under the `iosxr` top level key.  
+
+### Implement using tasks
+
+The `configure_lldp` function can also be implemented using the `tasks` directive
+instead of the `roles` directive.  By using the `tasks` directive, you can
+control when the fact collection is run. 
+
+Below is an example of how to use the `configure_lldp` function with `tasks`.
+
+```
+- hosts: iosxr
+
+  tasks:
+    - name: set lldp to iosxr devices
+      import_role:
+        name: ansible-network.cisco_iosxr
+        tasks_from: configure_lldp
+      vars:
+        lldp:
+          - holdtime: 60
+            reinit: 4
+            timer: 60
+            tlv-select: management-address
+            interface: GigabitEthernet 0/0/0/3
+            receive: disable
+            transmit: disable
+```
+
+## Adding new parsers
+
+Over time new parsers can be added (or updated) to the role to add additional
+or enhanced functionality.  To add or update parsers perform the following
+steps:
+
+* Add (or update) command parser located in `parse_templates/cli`
+
+## Arguments
+
+### holdtime
+
+LLDP holdtime specifies the length of time that information from an LLDP packet should
+be held by the receiving device before aging and removing it.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### reinit
+
+LLDP reint specifies the length of time, the initialization of LLDP on an interface should 
+be delayed.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### timer
+
+LLDP timer specifies the LLDP packet rate.
+
+The default value is `omit` which means even if the user doesn't pass the respective 
+value the role will continue to run without any failure.
+
+### tlv-select
+LLDP tlv-select specifies that transmission of the selected TLV in LLDP packets is disabled.
+The tlv-name can be one of these LLDP TLV types:
+
+* management-address
+* port-description
+* system-capabilities
+* system-description
+* system-name
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### interface
+
+When you enable LLDP globally on the router, all supported interfaces are automatically 
+enabled for LLDP receive and transmit operations. It can be overriden by disabling these 
+operations for a particular interface.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### receive
+
+LLDP receive disables LLDP receive operations on the interface.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### transmit
+
+LLDP receive disables LLDP transmit operations on the interface.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### state
+
+This sets the LLDP value to the Cisco IOS-XR device and if the value of the state is changed
+to `absent`, the role will go ahead and try to delete the condifured LLDP via the arguments
+passed.
+
+The default value is `present` which means even if the user doesn't pass the respective
+argument, the role will go ahead and try to set the LLDP via the arguments passed to the 
+Cisco IOS-XR device.
+
+## Notes
+
+None

--- a/docs/configure_lldp.md
+++ b/docs/configure_lldp.md
@@ -113,22 +113,15 @@ When you enable LLDP globally on the router, all supported interfaces are automa
 enabled for LLDP receive and transmit operations. It can be overriden by disabling these 
 operations for a particular interface.
 
-The default value is `omit` which means even if the user doesn't pass the respective
-value the role will continue to run without any failure.
-
 ### receive
 
-LLDP receive disables LLDP receive operations on the interface.
-
-The default value is `omit` which means even if the user doesn't pass the respective
-value the role will continue to run without any failure.
+LLDP receive disables LLDP receive operations on the interface. It can only be set if value
+of interface is set as `recieve` operations will be disabled on the respective interface.
 
 ### transmit
 
-LLDP receive disables LLDP transmit operations on the interface.
-
-The default value is `omit` which means even if the user doesn't pass the respective
-value the role will continue to run without any failure.
+LLDP receive disables LLDP transmit operations on the interface. It can only be set if value
+of interface is set as `transmit` operations will be disabled on the respective interface.
 
 ### state
 

--- a/docs/configure_lldp.md
+++ b/docs/configure_lldp.md
@@ -11,7 +11,7 @@ using either the `roles` directive or the `tasks` directive.  If no other
 options are provided, then all of the available facts will be collected for 
 the device.
 
-Below is an example of how to use the `roles` directive to set VLANs on the 
+Below is an example of how to use the `roles` directive to set LLDP on the
 Cisco IOS-XR device.
 
 ```

--- a/tasks/configure_lldp.yaml
+++ b/tasks/configure_lldp.yaml
@@ -1,4 +1,22 @@
 ---
+- name: "check for required fact - interface when lldp receive is defined"
+  fail:
+    msg: "missing required fact: Interface"
+  with_items: "{{ lldp }}"
+  when: ( item.interface is not defined and item.receive is defined)
+  loop_control:
+    loop_var: item
+  delegate_to: localhost
+
+- name: "check for required fact - interface when lldp transmit is defined"
+  fail:
+    msg: "missing required fact: Interface"
+  with_items: "{{ lldp }}"
+  when: ( item.interface is not defined and item.transmit is defined)
+  loop_control:
+    loop_var: item
+  delegate_to: localhost
+
 - name: "fetch template for configuring LLDP"
   set_fact:
     iosxr_config_text: "{{ lookup('config_template', 'configure_lldp.j2') }}"

--- a/tasks/configure_lldp.yaml
+++ b/tasks/configure_lldp.yaml
@@ -1,0 +1,8 @@
+---
+- name: "fetch template for configuring LLDP"
+  set_fact:
+    iosxr_config_text: "{{ lookup('config_template', 'configure_lldp.j2') }}"
+  when: lldp
+
+- include_tasks: config_manager/load.yaml
+  when: lldp

--- a/templates/configure_lldp.j2
+++ b/templates/configure_lldp.j2
@@ -16,10 +16,10 @@ timer {{ item.timer | default(omit) }}
 tlv-select {{ item.tlv_select | default(omit) }} disable
 
 {% if item.interface is defined %}
-interface {{ item.interface | default(omit) }}
+interface {{ item.interface }}
 lldp
-receive {{ item.receive | default(omit) }}
-transmit {{ item.transmit | default(omit) }}
+receive {{ item.receive }}
+transmit {{ item.transmit }}
 {% endif %}
 
 {% endif %}

--- a/templates/configure_lldp.j2
+++ b/templates/configure_lldp.j2
@@ -1,0 +1,26 @@
+{% for item in lldp %}
+
+{% if item.state is defined and item.state == 'absent' %}
+no lldp
+{% if item.interface is defined %}
+interface {{ item.interface | default(omit) }}
+no lldp
+{% endif %}
+
+{% else %}
+
+lldp
+holdtime {{ item.holdtime | default(omit) }}
+reinit {{ item.reinit | default(omit) }}
+timer {{ item.timer | default(omit) }}
+tlv-select {{ item.tlv_select | default(omit) }} disable
+
+{% if item.interface is defined %}
+interface {{ item.interface | default(omit) }}
+lldp
+receive {{ item.receive | default(omit) }}
+transmit {{ item.transmit | default(omit) }}
+{% endif %}
+
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
Added `configure_lldp` and `configure_lldp` jinja template for Cisco IOS-XR device provider to configure lldp using `iosxr` device provider role.

To configure lldp via this role user needs to build their playbook as:
```
---
- hosts: iosxr
  gather_facts: no
  tasks:
    - import_role:
        name: cisco_iosxr
        tasks_from: configure_lldp
      vars:
        lldp:
        - holdtime: 60
           reinit: 4
           timer: 60
           tlv_select: management-address
           interface: GigabitEthernet 0/0/0/3
           receive: disable
           transmit: disable
           #state: absent
```